### PR TITLE
feat(cli): fetch latest genehub-learner from registry during auto-install

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -114,7 +114,7 @@ export const installCommand = new Command('install')
               ? join(homedir(), '.nanobot', 'workspace')
               : join(process.cwd(), '.genehub');
 
-        const engine = new LearningEngine({ workspaceDir, adapter });
+        const engine = new LearningEngine({ workspaceDir, adapter, client });
         const learnSpinner = ora('生成学习任务...').start();
         await engine.createLearningTask(manifest);
         learnSpinner.succeed('学习任务已创建');

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -29,7 +29,7 @@ export const learnCommand = new Command('learn')
     const adapter = opts.product ? getAdapter(opts.product) : await detectAdapter();
 
     const workspaceDir = getWorkspaceDir(adapter.product);
-    const engine = new LearningEngine({ workspaceDir, adapter });
+    const engine = new LearningEngine({ workspaceDir, adapter, client });
 
     if (opts.check) {
       const spinner = ora('检查学习结果...').start();

--- a/packages/sdk/typescript/src/learning/engine.ts
+++ b/packages/sdk/typescript/src/learning/engine.ts
@@ -43,10 +43,6 @@ export class LearningEngine {
         manifest = await this.client.getManifest('genehub-learner');
       } catch (err) {
         // Fallback to built-in manifest if remote fetch fails
-        console.warn(
-          '[GeneHub] Failed to fetch latest genehub-learner, using built-in version.',
-          err,
-        );
       }
     }
 

--- a/packages/sdk/typescript/src/learning/engine.ts
+++ b/packages/sdk/typescript/src/learning/engine.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { GeneAdapter, GeneManifest } from '@nodeskai/genehub-types';
+import type { GeneHubClient } from '../client.js';
 import { META_LEARNER_MANIFEST } from './meta-gene.js';
 import { generateForgetTaskMarkdown, generateLearningTaskMarkdown } from './prompts.js';
 import type { LearningResult, LearningTask } from './task.js';
@@ -8,15 +9,18 @@ import type { LearningResult, LearningTask } from './task.js';
 export type LearningEngineOptions = {
   workspaceDir: string;
   adapter?: GeneAdapter;
+  client?: GeneHubClient;
 };
 
 export class LearningEngine {
   private workspaceDir: string;
   private adapter?: GeneAdapter;
+  private client?: GeneHubClient;
 
   constructor(options: LearningEngineOptions) {
     this.workspaceDir = options.workspaceDir;
     this.adapter = options.adapter;
+    this.client = options.client;
   }
 
   private get tasksDir(): string {
@@ -33,7 +37,20 @@ export class LearningEngine {
     const installed = await this.adapter.isInstalled('genehub-learner');
     if (installed) return false;
 
-    await this.adapter.install(META_LEARNER_MANIFEST, { force: true });
+    let manifest = META_LEARNER_MANIFEST;
+    if (this.client) {
+      try {
+        manifest = await this.client.getManifest('genehub-learner');
+      } catch (err) {
+        // Fallback to built-in manifest if remote fetch fails
+        console.warn(
+          '[GeneHub] Failed to fetch latest genehub-learner, using built-in version.',
+          err,
+        );
+      }
+    }
+
+    await this.adapter.install(manifest, { force: true });
     await this.injectBootInstruction();
     return true;
   }


### PR DESCRIPTION
Change built-in genehub-learner to pull from registry if available, with fallback to local manifest.