### PR TITLE
feat(sdk): Nanobot Adapter 测试与静默失败告警

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,7 @@ AI 员工模板是最高层抽象，GeneHub 存储公共模板（面向社区）
 | 适配器 | 目标产品 | 注入方式 |
 |--------|---------|---------|
 | OpenClaw Adapter | openClaw / NoDeskClaw | SKILL.md + openclaw.json（NFS / API） | 初期 |
-| nanobot Adapter | nanobot | 配置注入（待定） | 初期 |
+| nanobot Adapter | nanobot | 配置注入（Future：capabilities/requires 校验与注入） | 初期 |
 | Generic Adapter | 通用 Agent | 标准学习协议 HTTP 回调 | 初期 |
 | DeskClaw Adapter | DeskClaw | .cursor/rules/ + SKILL.md | 后续扩展 |
 
@@ -603,6 +603,8 @@ GitHub OAuth                   API Key
 | POST | `/genes/:slug/effectiveness` | 效能数据上报（EMA 算法） | 已实现 |
 | POST | `/genomes/:slug/installed` | 基因组安装计数上报 | 已实现 |
 | POST | `/effectiveness/batch` | 批量效能上报 | Future |
+
+删除基因/基因组/模板时，先删除 Gitea 对应仓库再删除 DB 记录；Gitea 删除失败时请求返回 5xx，避免 DB 已删但 Gitea 残留导致同 slug 无法再创建。
 
 #### 审核
 

--- a/packages/sdk/typescript/src/__tests__/nanobot-adapter.test.ts
+++ b/packages/sdk/typescript/src/__tests__/nanobot-adapter.test.ts
@@ -1,0 +1,145 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { GeneManifest } from '@nodeskai/genehub-types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NanobotAdapter } from '../adapters/nanobot.js';
+
+const TEST_MANIFEST: GeneManifest = {
+  slug: 'test-gene',
+  name: '测试基因',
+  version: '1.0.0',
+  description: '测试用基因',
+  short_description: '测试',
+  category: 'development',
+  tags: ['ability'],
+  compatibility: [{ product: 'nanobot', min_version: '0.1.0' }],
+  dependencies: [],
+  synergies: [],
+  skill: { name: 'test-gene', always: false, content: '你是一个测试基因' },
+  rules: [],
+  mcp_servers: [],
+};
+
+describe('NanobotAdapter', () => {
+  let tempDir: string;
+  let adapter: NanobotAdapter;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'genehub-nanobot-'));
+    const workspace = join(tempDir, 'workspace');
+    const configPath = join(tempDir, 'config.json');
+    await mkdir(join(workspace, 'skills'), { recursive: true });
+    await writeFile(configPath, '{}');
+
+    adapter = new NanobotAdapter({ workspace, configPath });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('detect() 当 config.json 存在时应返回 true', async () => {
+    expect(await adapter.detect()).toBe(true);
+  });
+
+  it('detect() 当 config.json 不存在时应返回 false', async () => {
+    const noConfigAdapter = new NanobotAdapter({
+      workspace: join(tempDir, 'workspace'),
+      configPath: join(tempDir, 'nonexistent.json'),
+    });
+    expect(await noConfigAdapter.detect()).toBe(false);
+  });
+
+  it('install() 应写入 workspace/skills/<name>/SKILL.md', async () => {
+    const result = await adapter.install(TEST_MANIFEST);
+    expect(result.success).toBe(true);
+    expect(result.slug).toBe('test-gene');
+    expect(result.files.length).toBeGreaterThanOrEqual(1);
+
+    const skillPath = join(tempDir, 'workspace', 'skills', 'test-gene', 'SKILL.md');
+    const content = await readFile(skillPath, 'utf-8');
+    expect(content).toContain('测试基因');
+    expect(content).toMatch(/version:\s*1\.0\.0/);
+  });
+
+  it('uninstall() 应删除技能目录', async () => {
+    await adapter.install(TEST_MANIFEST);
+    const result = await adapter.uninstall('test-gene');
+    expect(result.success).toBe(true);
+    expect(await adapter.isInstalled('test-gene')).toBe(false);
+  });
+
+  it('isInstalled() 安装后应返回 true，未安装返回 false', async () => {
+    expect(await adapter.isInstalled('test-gene')).toBe(false);
+    await adapter.install(TEST_MANIFEST);
+    expect(await adapter.isInstalled('test-gene')).toBe(true);
+  });
+
+  it('getInstalledVersion() 应从 SKILL.md front matter 解析版本', async () => {
+    await adapter.install(TEST_MANIFEST);
+    const version = await adapter.getInstalledVersion('test-gene');
+    expect(version).toBe('1.0.0');
+  });
+
+  it('getInstalledVersion() 未安装时应返回 null', async () => {
+    expect(await adapter.getInstalledVersion('test-gene')).toBeNull();
+  });
+
+  it('list() 应遍历 skills 目录并返回已安装基因', async () => {
+    await adapter.install(TEST_MANIFEST);
+    const list = await adapter.list();
+    expect(list.length).toBe(1);
+    expect(list[0].slug).toBe('test-gene');
+    expect(list[0].version).toBe('1.0.0');
+  });
+
+  it('list() 无技能时应返回空数组', async () => {
+    const list = await adapter.list();
+    expect(list).toEqual([]);
+  });
+
+  it('mergeNanobotMcpConfig() 应将 MCP 配置合并到 config.json', async () => {
+    const manifestWithMcp: GeneManifest = {
+      ...TEST_MANIFEST,
+      mcp_servers: [
+        {
+          name: 'test-mcp',
+          command: 'npx',
+          args: ['-y', 'test-server'],
+          env: {},
+        },
+      ],
+    };
+    await adapter.install(manifestWithMcp);
+
+    const configPath = join(tempDir, 'config.json');
+    const raw = await readFile(configPath, 'utf-8');
+    const config = JSON.parse(raw);
+    expect(config.tools?.mcpServers?.['test-mcp']).toBeDefined();
+    expect(config.tools.mcpServers['test-mcp'].command).toBe('npx');
+    expect(config.tools.mcpServers['test-mcp'].args).toEqual(['-y', 'test-server']);
+  });
+
+  it('mergeNanobotMcpConfig() 当 config.json 不存在时应 console.warn 且不抛错', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const noConfigAdapter = new NanobotAdapter({
+      workspace: join(tempDir, 'workspace'),
+      configPath: join(tempDir, 'missing.json'),
+    });
+    const manifestWithMcp: GeneManifest = {
+      ...TEST_MANIFEST,
+      mcp_servers: [{ name: 'mcp1', command: 'cmd', args: [], env: {} }],
+    };
+
+    await noConfigAdapter.install(manifestWithMcp);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[NanobotAdapter]'),
+      expect.any(String),
+      expect.any(String),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/sdk/typescript/src/adapters/nanobot.ts
+++ b/packages/sdk/typescript/src/adapters/nanobot.ts
@@ -12,14 +12,17 @@ import type {
 import { BaseAdapter } from './base.js';
 
 const DEFAULT_WORKSPACE = join(homedir(), '.nanobot', 'workspace');
+const DEFAULT_CONFIG_PATH = join(homedir(), '.nanobot', 'config.json');
 
 export class NanobotAdapter extends BaseAdapter {
   readonly product = 'nanobot';
   private workspace: string;
+  private configPath: string;
 
-  constructor(options?: { workspace?: string }) {
+  constructor(options?: { workspace?: string; configPath?: string }) {
     super();
     this.workspace = options?.workspace ?? DEFAULT_WORKSPACE;
+    this.configPath = options?.configPath ?? DEFAULT_CONFIG_PATH;
   }
 
   private get skillsDir(): string {
@@ -28,7 +31,7 @@ export class NanobotAdapter extends BaseAdapter {
 
   async detect(): Promise<boolean> {
     try {
-      await stat(join(homedir(), '.nanobot', 'config.json'));
+      await stat(this.configPath);
       return true;
     } catch {
       return false;
@@ -220,13 +223,16 @@ export class NanobotAdapter extends BaseAdapter {
   }
 
   private async mergeNanobotMcpConfig(mcpServers: GeneManifest['mcp_servers']): Promise<void> {
-    const configPath = join(homedir(), '.nanobot', 'config.json');
-
     let config: Record<string, unknown> = {};
     try {
-      const raw = await readFile(configPath, 'utf-8');
+      const raw = await readFile(this.configPath, 'utf-8');
       config = JSON.parse(raw);
-    } catch {
+    } catch (err) {
+      console.warn(
+        '[NanobotAdapter] config.json 不存在或读取失败，MCP 配置未写入:',
+        this.configPath,
+        err instanceof Error ? err.message : err,
+      );
       return;
     }
 
@@ -243,6 +249,6 @@ export class NanobotAdapter extends BaseAdapter {
       };
     }
 
-    await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    await writeFile(this.configPath, JSON.stringify(config, null, 2), 'utf-8');
   }
 }


### PR DESCRIPTION
- NanobotAdapter 支持可选 configPath 便于测试
- mergeNanobotMcpConfig 失败时 console.warn 替代静默
- 新增 nanobot-adapter 单测 11 例
- docs: nanobot 配置注入标注为 Future

Made-with: Cursor