### PR TITLE
feat(sdk): NanobotAdapter 校验与错误区分 + CLI 联邦搜索

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ AI 员工模板是最高层抽象，GeneHub 存储公共模板（面向社区）
 # 已实现命令
 genehub install <gene-slug>       # 安装基因（支持 @version、--force、--learn、--target）
 genehub uninstall <gene-slug>     # 卸载基因
-genehub search <keyword>          # 搜索基因（当前本地搜索，计划接入联邦搜索）
+genehub search <keyword>          # 搜索基因（默认联邦搜索；--local 仅本地 DB）
 genehub list                      # 列出已安装基因
 genehub publish <path>            # 发布基因（自动检测 CLAUDE.md/SKILL.md/AGENTS.md，无需预建 gene.yaml）
 genehub publish <path> -y         # 非交互模式发布（使用默认值）
@@ -1365,8 +1365,8 @@ MINIMAX_API_KEY: sk-xxx
 - [ ] 全文搜索升级（Meilisearch）
 - [ ] DeskClaw Adapter（后续扩展）
 - [ ] CLI `info` 命令
-- [ ] CLI `search` 接入联邦搜索
-- [ ] SDK `federatedSearch()` 方法
+- [x] CLI `search` 接入联邦搜索（默认联邦，`--local` 仅本地）
+- [x] SDK `federatedSearch()` 方法
 - [ ] `POST /resolve` 批量解析
 - [ ] `GET /genes/:slug/variants` 变体列表
 - [ ] `POST /genes/:slug/deprecate` 废弃基因

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ genehub auth logout     # 退出登录（清除本地 token）
 | `genehub auth login` | GitHub OAuth 登录 |
 | `genehub auth status` | 查看登录状态 |
 | `genehub auth logout` | 退出登录 |
-| `genehub search [keyword]` | 搜索基因库 |
+| `genehub search [keyword]` | 搜索基因库（默认联邦搜索；`--local` 仅本地 DB） |
 | `genehub install <slug>` | 安装基因到当前 Agent 环境 |
 | `genehub uninstall <slug>` | 卸载基因 |
 | `genehub publish <path>` | 发布基因到 Registry（自动检测 CLAUDE.md / SKILL.md / AGENTS.md） |

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -7,23 +7,58 @@ export const searchCommand = new Command('search')
   .description('搜索基因库')
   .argument('[keyword]', '搜索关键词')
   .option('-c, --category <category>', '按分类过滤')
-  .option('-t, --tags <tags>', '按标签过滤（逗号分隔）')
-  .option('--compat <product>', '按兼容产品过滤')
-  .option('-s, --sort <sort>', '排序方式（newest / popular / rating）', 'newest')
-  .option('--page <page>', '页码', '1')
+  .option('-t, --tags <tags>', '按标签过滤（逗号分隔，仅 --local 时有效）')
+  .option('--compat <product>', '按兼容产品过滤（仅 --local 时有效）')
+  .option('-s, --sort <sort>', '排序方式（newest / popular / rating，仅 --local 时有效）', 'newest')
+  .option('--page <page>', '页码（仅 --local 时有效）', '1')
+  .option('--local', '仅搜索本地 DB，不查 ClawHub 等外部源', false)
+  .option('--limit <n>', '联邦搜索返回条数（非 --local 时有效）', '20')
   .option('--json', 'JSON 格式输出', false)
   .action(async (keyword: string | undefined, opts) => {
     const config = await loadConfig();
     const client = new GeneHubClient({ registryUrl: config.registryUrl, token: config.token });
 
     try {
-      const result = await client.searchGenes({
-        q: keyword,
+      if (opts.local) {
+        const result = await client.searchGenes({
+          q: keyword,
+          category: opts.category,
+          tags: opts.tags?.split(','),
+          compatibility: opts.compat,
+          sort: opts.sort,
+          page: Number(opts.page),
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        if (result.items.length === 0) {
+          output.info('未找到匹配的基因');
+          return;
+        }
+
+        output.table(
+          ['slug', '名称', '版本', '分类', '兼容', '安装数'],
+          result.items.map((g) => [
+            g.slug,
+            g.name,
+            g.version,
+            g.category,
+            (g.compatibility as string[]).join(', '),
+            String(g.install_count),
+          ]),
+        );
+
+        output.info(`共 ${result.total} 条结果，第 ${result.page}/${result.total_pages} 页`);
+        return;
+      }
+
+      const result = await client.federatedSearch({
+        q: keyword ?? '',
         category: opts.category,
-        tags: opts.tags?.split(','),
-        compatibility: opts.compat,
-        sort: opts.sort,
-        page: Number(opts.page),
+        limit: Number(opts.limit) || 20,
       });
 
       if (opts.json) {
@@ -36,19 +71,15 @@ export const searchCommand = new Command('search')
         return;
       }
 
+      const description = (g: { name: string; description: string | null }) =>
+        (g.description ?? g.name).slice(0, 24);
       output.table(
-        ['slug', '名称', '版本', '分类', '兼容', '安装数'],
-        result.items.map((g) => [
-          g.slug,
-          g.name,
-          g.version,
-          g.category,
-          (g.compatibility as string[]).join(', '),
-          String(g.install_count),
-        ]),
+        ['slug', '名称', '版本', '描述', '来源'],
+        result.items.map((g) => [g.slug, g.name, g.version ?? '-', description(g), g.source]),
       );
 
-      output.info(`共 ${result.total} 条结果，第 ${result.page}/${result.total_pages} 页`);
+      const { local, clawhub } = result.sources;
+      output.info(`共 ${result.total} 条结果（本地 ${local}，ClawHub ${clawhub}）`);
     } catch (err) {
       output.fail(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/sdk/typescript/src/__tests__/client.test.ts
+++ b/packages/sdk/typescript/src/__tests__/client.test.ts
@@ -35,6 +35,72 @@ describe('GeneHubClient', () => {
     expect(result).toEqual(mockData);
   });
 
+  it('federatedSearch(q) 应请求 /api/v1/genes/search 并返回合并结果', async () => {
+    const mockData = {
+      query: 'task',
+      total: 2,
+      items: [
+        {
+          slug: 'task-discipline',
+          name: '任务纪律',
+          description: null,
+          version: '1.0.0',
+          category: null,
+          tags: [],
+          source: 'local',
+          score: 1,
+          install_count: null,
+          avg_rating: null,
+        },
+        {
+          slug: 'some-gene',
+          name: 'Some',
+          description: null,
+          version: '2.1.0',
+          category: null,
+          tags: [],
+          source: 'clawhub',
+          score: 0.9,
+          install_count: null,
+          avg_rating: null,
+        },
+      ],
+      sources: { local: 1, clawhub: 1 },
+    };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ code: 0, data: mockData }),
+    });
+
+    const result = await client.federatedSearch({ q: 'task' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/api/v1/genes/search?q=task`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    );
+    expect(result).toEqual(mockData);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].source).toBe('local');
+    expect(result.items[1].source).toBe('clawhub');
+  });
+
+  it('federatedSearch 支持 category 与 limit 参数', async () => {
+    const mockData = { query: 'x', total: 0, items: [], sources: { local: 0, clawhub: 0 } };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ code: 0, data: mockData }),
+    });
+
+    await client.federatedSearch({ q: 'x', category: 'productivity', limit: 10 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/api/v1/genes/search?q=x&category=productivity&limit=10`,
+      expect.any(Object),
+    );
+  });
+
   it('getGene(slug) 应构造正确 URL 并返回基因数据', async () => {
     const mockGene = { slug: 'my-gene', name: 'My Gene', version: '1.0.0' };
     fetchMock.mockResolvedValueOnce({

--- a/packages/sdk/typescript/src/__tests__/nanobot-adapter.test.ts
+++ b/packages/sdk/typescript/src/__tests__/nanobot-adapter.test.ts
@@ -106,6 +106,7 @@ describe('NanobotAdapter', () => {
       mcp_servers: [
         {
           name: 'test-mcp',
+          transport: 'stdio',
           command: 'npx',
           args: ['-y', 'test-server'],
           env: {},
@@ -130,13 +131,60 @@ describe('NanobotAdapter', () => {
     });
     const manifestWithMcp: GeneManifest = {
       ...TEST_MANIFEST,
-      mcp_servers: [{ name: 'mcp1', command: 'cmd', args: [], env: {} }],
+      mcp_servers: [{ name: 'mcp1', transport: 'stdio', command: 'cmd', args: [], env: {} }],
     };
 
     await noConfigAdapter.install(manifestWithMcp);
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('[NanobotAdapter]'),
+      expect.any(String),
+      expect.any(String),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('mergeNanobotMcpConfig() 当 config.json 内容非对象时应 warn 且不写入', async () => {
+    const invalidConfigPath = join(tempDir, 'invalid-object.json');
+    await writeFile(invalidConfigPath, 'null', 'utf-8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const badAdapter = new NanobotAdapter({
+      workspace: join(tempDir, 'ws2'),
+      configPath: invalidConfigPath,
+    });
+    const manifestWithMcp: GeneManifest = {
+      ...TEST_MANIFEST,
+      mcp_servers: [{ name: 'mcp1', transport: 'stdio', command: 'cmd', args: [], env: {} }],
+    };
+
+    await badAdapter.install(manifestWithMcp);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('内容不是有效对象'),
+      invalidConfigPath,
+    );
+    const stillRaw = await readFile(invalidConfigPath, 'utf-8');
+    expect(stillRaw).toBe('null');
+    warnSpy.mockRestore();
+  });
+
+  it('mergeNanobotMcpConfig() 当 config.json JSON 格式错误时应 warn 解析失败', async () => {
+    const badJsonPath = join(tempDir, 'bad-json.json');
+    await writeFile(badJsonPath, '{ invalid }', 'utf-8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const badAdapter = new NanobotAdapter({
+      workspace: join(tempDir, 'ws3'),
+      configPath: badJsonPath,
+    });
+    const manifestWithMcp: GeneManifest = {
+      ...TEST_MANIFEST,
+      mcp_servers: [{ name: 'mcp1', transport: 'stdio', command: 'cmd', args: [], env: {} }],
+    };
+
+    await badAdapter.install(manifestWithMcp);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('解析失败'),
       expect.any(String),
       expect.any(String),
     );

--- a/packages/sdk/typescript/src/adapters/nanobot.ts
+++ b/packages/sdk/typescript/src/adapters/nanobot.ts
@@ -226,13 +226,41 @@ export class NanobotAdapter extends BaseAdapter {
     let config: Record<string, unknown> = {};
     try {
       const raw = await readFile(this.configPath, 'utf-8');
-      config = JSON.parse(raw);
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        console.warn(
+          '[NanobotAdapter] config.json 内容不是有效对象，MCP 配置未写入:',
+          this.configPath,
+        );
+        return;
+      }
+      config = parsed as Record<string, unknown>;
     } catch (err) {
-      console.warn(
-        '[NanobotAdapter] config.json 不存在或读取失败，MCP 配置未写入:',
-        this.configPath,
-        err instanceof Error ? err.message : err,
-      );
+      const errorDetail = err instanceof Error ? err.message : err;
+      if (
+        err &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code?: string }).code === 'ENOENT'
+      ) {
+        console.warn(
+          '[NanobotAdapter] config.json 不存在，MCP 配置未写入:',
+          this.configPath,
+          errorDetail,
+        );
+      } else if (err instanceof SyntaxError) {
+        console.warn(
+          '[NanobotAdapter] config.json 解析失败（JSON 格式错误），MCP 配置未写入:',
+          this.configPath,
+          errorDetail,
+        );
+      } else {
+        console.warn(
+          '[NanobotAdapter] config.json 读取或解析失败，MCP 配置未写入:',
+          this.configPath,
+          errorDetail,
+        );
+      }
       return;
     }
 

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -5,6 +5,7 @@ import type {
   ApiResponse,
   CreateAgentTemplateRequest,
   CreateGenomeRequest,
+  FederatedSearchResult,
   Gene,
   GeneListParams,
   GeneManifest,
@@ -69,6 +70,19 @@ export class GeneHubClient {
 
     const query = qs.toString();
     return this.request<PaginatedData<Gene>>(`/api/v1/genes${query ? `?${query}` : ''}`);
+  }
+
+  /** 联邦搜索：合并本地 DB 与外部源（如 ClawHub）结果 */
+  async federatedSearch(params: {
+    q: string;
+    category?: string;
+    limit?: number;
+  }): Promise<FederatedSearchResult> {
+    const qs = new URLSearchParams();
+    qs.set('q', params.q);
+    if (params.category) qs.set('category', params.category);
+    if (params.limit != null) qs.set('limit', String(params.limit));
+    return this.request<FederatedSearchResult>(`/api/v1/genes/search?${qs.toString()}`);
   }
 
   async getGene(slug: string): Promise<Gene> {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -101,12 +101,14 @@ export type FederatedGeneItem = {
   clawhub_display_name?: string;
 };
 
-export type FederatedSearchResponse = ApiResponse<{
+export type FederatedSearchResult = {
   query: string;
   total: number;
   items: FederatedGeneItem[];
   sources: { local: number; clawhub: number };
-}>;
+};
+
+export type FederatedSearchResponse = ApiResponse<FederatedSearchResult>;
 
 export type AgentTemplateListParams = {
   q?: string;


### PR DESCRIPTION
- NanobotAdapter: JSON 解析后校验为非空对象，否则 warn 并 return
- NanobotAdapter: catch 区分配置不存在(ENOENT)/JSON 格式错误(SyntaxError)/其他
- types: 导出 FederatedSearchResult
- SDK: 新增 federatedSearch()，请求 /api/v1/genes/search
- CLI search: 默认联邦搜索，表格展示来源(local/clawhub)，--local 仅本地
- 单测: federatedSearch 两例 + nanobot 内容非对象/格式错误两例 + mcp_servers transport
- docs: 里程碑与 CLI 说明更新

Made-with: Cursor